### PR TITLE
Mt 455 created jetpack compose only screen that matches up with the autosuggest sample screen

### DIFF
--- a/compose-sample/build.gradle
+++ b/compose-sample/build.gradle
@@ -36,6 +36,7 @@ android {
     }
     buildFeatures {
         compose true
+        viewBinding true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.3.0'
@@ -61,6 +62,7 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    implementation "androidx.compose.ui:ui-viewbinding:1.2.1"
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
     implementation project(":lib")
     implementation 'com.google.android.material:material:1.6.1'

--- a/compose-sample/src/main/java/com/what3words/compose/sample/ui/components/LabelCheckBox.kt
+++ b/compose-sample/src/main/java/com/what3words/compose/sample/ui/components/LabelCheckBox.kt
@@ -12,7 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.dimensionResource
+import com.what3words.compose.sample.R
 
 @Composable
 fun LabelCheckBox(
@@ -30,8 +31,8 @@ fun LabelCheckBox(
     ) {
         Checkbox(
             checked = checked, onCheckedChange = onCheckedChange,
+            modifier = Modifier.size(size = dimensionResource(id = R.dimen.normal_200)),
             interactionSource = interactionSource,
-            colors = CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary)
         )
         Text(text = text, style = MaterialTheme.typography.body2,
             modifier = Modifier.clickable(

--- a/compose-sample/src/main/java/com/what3words/compose/sample/ui/components/RadioGroup.kt
+++ b/compose-sample/src/main/java/com/what3words/compose/sample/ui/components/RadioGroup.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,23 +19,39 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
-import kotlin.math.max
+import com.what3words.compose.sample.R
 
-class RadioGroupState(val items: List<String>, selectedItemIndex: Int) {
-    var selected: String? by mutableStateOf(if (items.isNotEmpty()) items[selectedItemIndex] else null)
+class RadioGroupState<T>(val items: List<T>, selectedItemIndex: Int, val label: (T) -> String) {
+    var selected: T? by mutableStateOf(if (items.isNotEmpty()) items[selectedItemIndex] else null)
 }
 
 @Composable
-fun RadioGroup(
-    state: RadioGroupState,
+fun <T> RadioGroup(
+    state: RadioGroupState<T>,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        state.items.forEach { item: String ->
-            RadioGroupItem(selected = item == state.selected, onClick = {
-                state.selected = item
-            }, label = item)
+        val ripple = rememberRipple()
+        val interactionSource = remember {
+            MutableInteractionSource()
+        }
+        state.items.forEach { item: T ->
+            RadioGroupItem(
+                selected = item == state.selected,
+                label = state.label(item),
+                modifier = Modifier.selectable(
+                    selected = item == state.selected,
+                    role = Role.RadioButton,
+                    interactionSource = interactionSource,
+                    indication = ripple,
+                    enabled = true,
+                    onClick = { state.selected = item }
+                ),
+                onClick = { state.selected = item }
+            )
         }
     }
 }
@@ -49,8 +68,8 @@ private fun RadioGroupItem(
             MutableInteractionSource()
         }
         RadioButton(
-            selected = selected, onClick = onClick, interactionSource = interactionSource,
-            colors = RadioButtonDefaults.colors(selectedColor = MaterialTheme.colors.primary)
+            modifier = Modifier.size(size = dimensionResource(id = R.dimen.normal_200)),
+            selected = selected, onClick = onClick, interactionSource = interactionSource
         )
         Text(
             text = label,

--- a/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/CustomizeAutoSuggestSettingsScreen.kt
+++ b/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/CustomizeAutoSuggestSettingsScreen.kt
@@ -1,0 +1,129 @@
+package com.what3words.compose.sample.ui.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import com.what3words.components.compose.wrapper.W3WAutoSuggestTextFieldState
+import com.what3words.compose.sample.R
+import com.what3words.compose.sample.ui.components.LabelCheckBox
+import com.what3words.compose.sample.ui.components.RadioGroup
+import com.what3words.compose.sample.ui.components.RadioGroupState
+import com.what3words.compose.sample.ui.model.VoiceOption
+import com.what3words.javawrapper.request.AutosuggestOptions
+
+// a group of ui components that is used to configure the w3w autosuggestion settings
+@Composable
+fun CustomizeAutoSuggestSettingsScreen(
+    autoSuggestTextFieldState: W3WAutoSuggestTextFieldState,
+    modifier: Modifier = Modifier
+) {
+    val autoSuggestOptions = remember {
+        AutosuggestOptions().apply {
+            preferLand = true
+        }
+    }
+
+    LaunchedEffect(key1 = true, block = {
+        autoSuggestTextFieldState.options(options = autoSuggestOptions)
+    })
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // customize the autosuggest component label
+        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+            Text(
+                text = stringResource(R.string.txt_label_customize_the_autosuggest_component),
+                style = MaterialTheme.typography.body2
+            )
+        }
+
+        // return coordinates checkbox
+        LabelCheckBox(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            checked = autoSuggestTextFieldState.returnCoordinates,
+            onCheckedChange = {
+                autoSuggestTextFieldState.returnCoordinates = it
+            },
+            text = stringResource(R.string.txt_label_return_coordinates)
+        )
+
+        // prefer land checkbox
+        var preferLand by remember { mutableStateOf(false) }
+        LabelCheckBox(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            checked = preferLand,
+            onCheckedChange = {
+                preferLand = it
+                autoSuggestOptions.preferLand = preferLand
+                autoSuggestTextFieldState.options(options = autoSuggestOptions)
+            },
+            text = stringResource(R.string.txt_label_prefer_land)
+        )
+
+        // voice options radio group state
+        val voiceOptionGroupState = remember {
+            RadioGroupState(
+                items = VoiceOption.values(),
+                selectedItemIndex = 0,
+                label = {
+                    it.label
+                }
+            )
+        }
+
+        /**
+         * observe the selected radio item [RadioGroupState.selected] so that you can update the [W3WAutoSuggestTextFieldState] accordingly
+         *  **/
+        LaunchedEffect(key1 = voiceOptionGroupState.selected, block = {
+            if (voiceOptionGroupState.selected != null) {
+                if (voiceOptionGroupState.selected == VoiceOption.DisableVoice) {
+                    autoSuggestTextFieldState.voiceEnabled(enabled = false)
+                } else {
+                    autoSuggestTextFieldState.voiceEnabled(
+                        enabled = true,
+                        type = voiceOptionGroupState.selected!!.type!!
+                    )
+                }
+            }
+        })
+
+        // voice option radio groupd
+        RadioGroup(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            state = voiceOptionGroupState
+        )
+
+        // allow invalid 3wa
+        LabelCheckBox(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            checked = autoSuggestTextFieldState.allowInvalid3wa,
+            onCheckedChange = {
+                autoSuggestTextFieldState.allowInvalid3wa = it
+            },
+            text = stringResource(R.string.txt_label_allow_invalid_3wa)
+        )
+
+        // allow flexible delimiters
+        LabelCheckBox(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            checked = autoSuggestTextFieldState.allowFlexibleDelimiters,
+            onCheckedChange = {
+                autoSuggestTextFieldState.allowFlexibleDelimiters = it
+            },
+            text = stringResource(R.string.txt_label_allow_flexible_delimiters)
+        )
+    }
+}

--- a/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/CustomizeAutoSuggestSettingsScreen.kt
+++ b/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/CustomizeAutoSuggestSettingsScreen.kt
@@ -3,12 +3,10 @@ package com.what3words.compose.sample.ui.screen
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,21 +18,34 @@ import androidx.compose.ui.res.stringResource
 import com.what3words.components.compose.wrapper.W3WAutoSuggestTextFieldState
 import com.what3words.compose.sample.R
 import com.what3words.compose.sample.ui.components.LabelCheckBox
+import com.what3words.compose.sample.ui.components.MultiLabelTextField
 import com.what3words.compose.sample.ui.components.RadioGroup
 import com.what3words.compose.sample.ui.components.RadioGroupState
 import com.what3words.compose.sample.ui.model.VoiceOption
 import com.what3words.javawrapper.request.AutosuggestOptions
+import com.what3words.javawrapper.request.Coordinates
+
+
+class CustomizeAutoSuggestSettingsScreenState() {
+    // use custom picker
+    var useCustomPicker: Boolean by mutableStateOf(value = false)
+
+    var clipToCountry: String by mutableStateOf(value = "")
+
+    var focus: String by mutableStateOf(value = "")
+}
 
 // a group of ui components that is used to configure the w3w autosuggestion settings
 @Composable
 fun CustomizeAutoSuggestSettingsScreen(
     autoSuggestTextFieldState: W3WAutoSuggestTextFieldState,
+    state: CustomizeAutoSuggestSettingsScreenState,
     modifier: Modifier = Modifier
 ) {
     val autoSuggestOptions = remember {
-        AutosuggestOptions().apply {
+        (AutosuggestOptions().apply {
             preferLand = true
-        }
+        })
     }
 
     LaunchedEffect(key1 = true, block = {
@@ -43,12 +54,10 @@ fun CustomizeAutoSuggestSettingsScreen(
 
     Column(modifier = modifier.fillMaxWidth()) {
         // customize the autosuggest component label
-        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-            Text(
-                text = stringResource(R.string.txt_label_customize_the_autosuggest_component),
-                style = MaterialTheme.typography.body2
-            )
-        }
+        Text(
+            text = stringResource(id = R.string.txt_label_customize_the_autosuggest_component),
+            style = MaterialTheme.typography.body2.copy(color = LocalContentColor.current.copy(alpha = 0.5f))
+        )
 
         // return coordinates checkbox
         LabelCheckBox(
@@ -57,11 +66,11 @@ fun CustomizeAutoSuggestSettingsScreen(
             onCheckedChange = {
                 autoSuggestTextFieldState.returnCoordinates = it
             },
-            text = stringResource(R.string.txt_label_return_coordinates)
+            text = stringResource(id = R.string.txt_label_return_coordinates)
         )
 
         // prefer land checkbox
-        var preferLand by remember { mutableStateOf(false) }
+        var preferLand by remember { mutableStateOf(value = false) }
         LabelCheckBox(
             modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
             checked = preferLand,
@@ -70,7 +79,7 @@ fun CustomizeAutoSuggestSettingsScreen(
                 autoSuggestOptions.preferLand = preferLand
                 autoSuggestTextFieldState.options(options = autoSuggestOptions)
             },
-            text = stringResource(R.string.txt_label_prefer_land)
+            text = stringResource(id = R.string.txt_label_prefer_land)
         )
 
         // voice options radio group state
@@ -106,6 +115,16 @@ fun CustomizeAutoSuggestSettingsScreen(
             state = voiceOptionGroupState
         )
 
+        // use custom picker
+        LabelCheckBox(
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
+            checked = state.useCustomPicker,
+            onCheckedChange = {
+                state.useCustomPicker = it
+            },
+            text = stringResource(id = R.string.txt_label_use_custom_picker)
+        )
+
         // allow invalid 3wa
         LabelCheckBox(
             modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.small_50)),
@@ -113,7 +132,7 @@ fun CustomizeAutoSuggestSettingsScreen(
             onCheckedChange = {
                 autoSuggestTextFieldState.allowInvalid3wa = it
             },
-            text = stringResource(R.string.txt_label_allow_invalid_3wa)
+            text = stringResource(id = R.string.txt_label_allow_invalid_3wa)
         )
 
         // allow flexible delimiters
@@ -123,7 +142,42 @@ fun CustomizeAutoSuggestSettingsScreen(
             onCheckedChange = {
                 autoSuggestTextFieldState.allowFlexibleDelimiters = it
             },
-            text = stringResource(R.string.txt_label_allow_flexible_delimiters)
+            text = stringResource(id = R.string.txt_label_allow_flexible_delimiters)
         )
+
+        // focus
+        MultiLabelTextField(
+            text = state.focus,
+            onTextChanged = {
+                state.focus = it
+                val latLong =
+                    state.focus.replace("\\s".toRegex(), "").split(",").filter { it.isNotEmpty() }
+                val lat = latLong.getOrNull(0)?.toDoubleOrNull()
+                val long = latLong.getOrNull(1)?.toDoubleOrNull()
+                if (lat != null && long != null) {
+                    autoSuggestOptions.focus = Coordinates(lat, long)
+                } else {
+                    autoSuggestOptions.focus = null
+                }
+                autoSuggestTextFieldState.options(options = autoSuggestOptions)
+            },
+            primaryLabel = stringResource(id = R.string.txt_label_focus),
+            secondaryLabel = stringResource(id = R.string.txt_label_focus_info)
+        )
+
+        // clip to country 
+        MultiLabelTextField(
+            text = state.clipToCountry,
+            onTextChanged = {
+                state.clipToCountry = it
+                autoSuggestOptions.clipToCountry =
+                    state.clipToCountry.replace("\\s".toRegex(), "").split(",")
+                        .filter { it.isNotEmpty() }
+                autoSuggestTextFieldState.options(options = autoSuggestOptions)
+            },
+            primaryLabel = stringResource(id = R.string.txt_label_clip_to_country),
+            secondaryLabel = stringResource(id = R.string.txt_label_clip_to_country_info)
+        )
+
     }
 }

--- a/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/W3WTextFieldInConstraintLayoutScreen.kt
+++ b/compose-sample/src/main/java/com/what3words/compose/sample/ui/screen/W3WTextFieldInConstraintLayoutScreen.kt
@@ -1,0 +1,125 @@
+package com.what3words.compose.sample.ui.screen
+
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.what3words.components.compose.wrapper.W3WAutoSuggestTextField
+import com.what3words.components.compose.wrapper.rememberW3WAutoSuggestTextFieldState
+import com.what3words.components.text.W3WAutoSuggestEditText
+import com.what3words.compose.sample.BuildConfig
+import com.what3words.compose.sample.R
+
+/**
+ * A jetpack compose screen that's intends to be replica of the W3WAutoSuggestComponent Sample(view-specific) app.
+ * Using the [W3WAutoSuggestTextField] as the jetpack compose's substitute for [W3WAutoSuggestEditText]
+ * **/
+@Composable
+fun W3WTextFieldInConstraintLayoutScreen(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val selectedInfo: MutableState<String?> = remember { mutableStateOf(null) }
+
+    ConstraintLayout(
+        modifier = modifier
+            .statusBarsPadding()
+            .fillMaxSize()
+            .verticalScroll(state = rememberScrollState())
+            .padding(horizontal = dimensionResource(id = R.dimen.normal_100))
+    ) {
+        val (headerTxt, w3wTextField, selectedInfoTxt, settingsColumn) = createRefs()
+
+        // welcome header
+        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+            Text(
+                text = stringResource(R.string.txt_label_welcome_to_autosuggest_sample),
+                modifier = Modifier
+                    .padding(
+                        top = dimensionResource(id = R.dimen.normal_125),
+                        bottom = dimensionResource(
+                            id = R.dimen.small_25
+                        )
+                    )
+                    .constrainAs(headerTxt) {
+                        linkTo(start = parent.start, end = parent.end)
+                        top.linkTo(anchor = parent.top)
+                        width = Dimension.fillToConstraints
+                    },
+                style = MaterialTheme.typography.body2
+            )
+        }
+
+        //  what3words autosuggest text component for compose
+        val w3wTextFieldState = rememberW3WAutoSuggestTextFieldState(apiKey = BuildConfig.W3W_API_KEY)
+
+        W3WAutoSuggestTextField(
+            modifier = Modifier.constrainAs(w3wTextField) {
+                linkTo(start = parent.start, end = parent.end)
+                top.linkTo(anchor = headerTxt.bottom)
+            },
+            state = w3wTextFieldState,
+            ref = w3wTextField,
+            onSuggestionWithCoordinates = {
+                if (it != null) {
+                    selectedInfo.value = context.resources.getString(
+                        R.string.suggestion_info_placeholder,
+                        it.words,
+                        it.country,
+                        it.nearestPlace,
+                        if (it.distanceToFocusKm == null) "N/A" else "${it.distanceToFocusKm}km",
+                        it.coordinates?.lat.toString(),
+                        it.coordinates?.lng.toString()
+                    )
+                } else {
+                    selectedInfo.value = ""
+                }
+            }
+        )
+
+        // selected address info text
+        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+            Text(
+                text = selectedInfo.value ?: "",
+                modifier = Modifier
+                    .defaultMinSize(minHeight = dimensionResource(id = R.dimen.large_200))
+                    .constrainAs(selectedInfoTxt) {
+                        linkTo(start = parent.start, end = parent.end)
+                        top.linkTo(w3wTextField.bottom)
+                        width = Dimension.fillToConstraints
+                    },
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        // group of components to configure the settings of the auto suggest edit text
+        CustomizeAutoSuggestSettingsScreen(
+            autoSuggestTextFieldState = w3wTextFieldState,
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.normal_200))
+                .constrainAs(settingsColumn) {
+                    linkTo(start = parent.start, end = parent.end)
+                    linkTo(top = selectedInfoTxt.bottom, bottom = parent.bottom)
+                    height = Dimension.fillToConstraints
+                }
+        )
+    }
+}

--- a/compose-sample/src/main/res/layout/custom_suggestion_picker.xml
+++ b/compose-sample/src/main/res/layout/custom_suggestion_picker.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.what3words.components.picker.W3WAutoSuggestPicker xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/suggestionPicker"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="@dimen/xlarge_margin"
+    android:layout_marginEnd="8dp"
+    android:elevation="4dp" />

--- a/compose-sample/src/main/res/values/strings.xml
+++ b/compose-sample/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <resources>
     <string name="app_name">compose-sample</string>
+    <string name="txt_label_focus">focus, i.e: 51.508354, -0.12549861</string>
+    <string name="txt_label_focus_info">Comma separated lat/lng of point to focus on. Example value:51.521251,-0.203586</string>
+    <string name="txt_label_clip_to_country">clip to country</string>
+    <string name="txt_label_clip_to_country_info">Confine results to a given country or comma separated list of countries. Example value: GB,US</string>
+    <string name="txt_label_use_custom_picker">use custom picker</string>
     <string name="txt_label_allow_flexible_delimiters">allow flexible delimiters</string>
     <string name="txt_label_allow_invalid_3wa">allow invalid 3wa</string>
     <string name="txt_label_prefer_land">prefer land</string>

--- a/compose-sample/src/main/res/values/themes.xml
+++ b/compose-sample/src/main/res/values/themes.xml
@@ -2,6 +2,6 @@
 <resources>
 
     <style name="Theme.What3wordscomponents" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/purple_700</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
 </resources>

--- a/lib/src/main/java/com/what3words/components/compose/utils/W3WAutoSuggestTextFieldStateUIUtils.kt
+++ b/lib/src/main/java/com/what3words/components/compose/utils/W3WAutoSuggestTextFieldStateUIUtils.kt
@@ -1,5 +1,6 @@
 package com.what3words.components.compose.utils
 
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import com.what3words.components.compose.wrapper.W3WAutoSuggestTextFieldState
@@ -48,17 +49,20 @@ internal fun AttachSuggestionPickerAndInvalidMessageView(
     onSuggestionWithCoordinates: ((SuggestionWithCoordinates?) -> Unit)?
 ) {
     LaunchedEffect(
-        key1 = state.defaultSuggestionPicker,
-        key2 = state.defaultInvalidAddressMessageView,
-        key3 = state.internalW3WAutoSuggestEditText,
+        state.defaultSuggestionPicker,
+        state.defaultInvalidAddressMessageView,
+        state.internalW3WAutoSuggestEditText,
+        state.customSuggestionPicker,
         block = {
-            if (state.defaultSuggestionPicker != null || state.defaultInvalidAddressMessageView != null) {
+            if (state.defaultSuggestionPicker != null || state.defaultInvalidAddressMessageView != null || state.customSuggestionPicker != null) {
                 state.internalW3WAutoSuggestEditText?.onSuggestionSelected(
-                    picker = state.defaultSuggestionPicker,
+                    picker = state.customSuggestionPicker ?: state.defaultSuggestionPicker,
                     invalidAddressMessageView = state.defaultInvalidAddressMessageView
                 ) {
                     onSuggestionWithCoordinates?.invoke(it)
                 }
+                if (state.customSuggestionPicker != null) state.defaultSuggestionPicker?.visibility =
+                    View.GONE
             }
         })
 }

--- a/lib/src/main/java/com/what3words/components/compose/wrapper/W3WAutoSuggestTextFieldState.kt
+++ b/lib/src/main/java/com/what3words/components/compose/wrapper/W3WAutoSuggestTextFieldState.kt
@@ -63,6 +63,7 @@ class W3WAutoSuggestTextFieldState(
     internal var internalW3WAutoSuggestEditText: W3WAutoSuggestEditText? by mutableStateOf(value = null)
 
     internal var defaultSuggestionPicker: W3WAutoSuggestPicker? by mutableStateOf(value = null)
+    var customSuggestionPicker: W3WAutoSuggestPicker? by mutableStateOf(value = null)
     internal var defaultErrorView: AppCompatTextView? by mutableStateOf(value = null)
     internal var defaultInvalidAddressMessageView: AppCompatTextView? by mutableStateOf(value = null)
     internal var defaultCorrectionPicker: W3WAutoSuggestCorrectionPicker? by mutableStateOf(value = null)


### PR DESCRIPTION
Created a Jetpack Compose-only screen that matches up with the autosuggest sample (xml/view) screen using our W3WAutoSuggestTextField as a Jetpack Compose's subtitle for the W3WAutoSuggestEditText.