### PR TITLE
Mt 475 migrate all sub projects in what 3 words android component to use the gradle version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,22 +16,20 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
-        classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jacoco:org.jacoco.core:0.8.7"
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath files(libs.class.superclass.protectionDomain.codeSource.location)
+        classpath files(testLibs.class.superclass.protectionDomain.codeSource.location)
     }
+}
+
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.klint) apply true // apply across all projects
+    alias(libs.plugins.sonarqube) apply true // apply across all projects
 }
 
 apply from: 'sonarqube.gradle'
 
-allprojects {
-    apply plugin: "org.jlleitschuh.gradle.ktlint"
-    apply plugin: 'org.sonarqube'
-}
 
 task clean(type: Delete) {
     delete rootProject.buildDir

--- a/compose-sample/build.gradle
+++ b/compose-sample/build.gradle
@@ -50,20 +50,19 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    implementation "androidx.compose.ui:ui-viewbinding:1.2.1"
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
     implementation project(":lib")
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation libs.androidx.core
+
+    implementation libs.bundles.compose.application
+
+    testImplementation testLibs.junit
+    androidTestImplementation testLibs.espresso
+
+    androidTestImplementation testLibs.androidx.junit
+    androidTestImplementation testLibs.androidx.compose.ui.junit
+
+    debugImplementation libs.compose.ui.tooling
+    debugImplementation libs.compose.ui.test.manifest
+    implementation libs.compose.view.binding
+    implementation libs.google.android.material
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,42 @@
+[versions]
+compose = "1.2.1"
+kotlin = "1.7.10"
+kotlinx-coroutine = "1.3.0"
+dokka = "0.9.17"
+playServices = "17.0.0"
+junit = "4.13.2"
+espresso = "3.4.0"
+androidGradlePlugin = "7.0.4"
+
+
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+klint = {id = "org.jlleitschuh.gradle.ktlint", version = "10.1.0"}
+sonarqube = {id = "org.sonarqube", version = "3.3"}
+
+dokka = { id = "org.jetbrains.dokka", version = "1.5.0" }
+errorprone = { id = "net.ltgt.errorprone", version = "2.0.2" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }
+protobuf = { id = "com.google.protobuf", version = "0.8.17" }
+animalsniffer = { id = "ru.vyarus.animalsniffer", version = "1.5.0" }
+googleJavaFormat = { id = "com.github.sherter.google-java-format", version = "0.9" }
+
+[libraries]
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+compose-constraint-layout = { module = "androidx.constraintlayout:constraintlayout-compose", version = "1.0.1" }
+compose-view-binding = { module = "androidx.compose.ui:ui-viewbinding", version = "1.2.1" }
+
+androidx-core = { module = "androidx.core:core-ktx", version = "1.9.0" }
+androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.3.1" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.3.1" }
+
+google-android-material = { module = "com.google.android.material:material", version = "1.6.1" }
+
+[bundles]
+compose-application = ['compose-ui', 'compose-material', 'androidx-activity-compose', 'androidx-lifecycle-runtime', 'compose-constraint-layout', 'compose-ui-tooling-preview']

--- a/gradle/testLibs.versions.toml
+++ b/gradle/testLibs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+junit = "4.13.2"
+espresso = "3.4.0"
+compose = "1.2.1"
+
+[libraries]
+junit = { module = "junit:junit", version.ref = "junit" }
+espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-junit = { module = "androidx.test.ext:junit", version = "1.1.3" }
+androidx-compose-ui-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,23 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
+    }
+
+    versionCatalogs {
+        // declares an additional catalog, named 'testLibs', from the 'test-libs.versionstoml' file
+        testLibs {
+            from(files('gradle/testLibs.versions.toml'))
+        }
     }
 }
 


### PR DESCRIPTION
- Created version catalogs for libraries and test-libraries dependencies 
- Migrated compose-sample module to use Gradle version catalog 
- Enabled IDE autocompletion feature for version catalog type-safe accessors